### PR TITLE
Edit Search Page so that captions are BELOW images

### DIFF
--- a/client/src/components/home/Hero/Hero.css
+++ b/client/src/components/home/Hero/Hero.css
@@ -126,10 +126,10 @@
 }
 
 .search-results-header {
-  margin: 10px 0px 30px 0px;
+  margin: 10px 0px 0px 0px;
   color: black;
   font-size: large;
-  height: 30px;
+  height: auto;
 }
 
 .search-results-length {
@@ -164,13 +164,13 @@
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  width: 300px;
+  width: 200px;
   margin: 35px;
   padding: 0px 30px;
 }
 
 .poster-img {
-  width: 300px;
+  width: 200px;
   height: auto;
   align-self: center;
 }

--- a/client/src/components/home/Hero/ResultCard.js
+++ b/client/src/components/home/Hero/ResultCard.js
@@ -3,11 +3,6 @@ import React from 'react';
 const ResultCard = props => {
   return (
     <div className="result-card" key={props.result.id} index={props.result.id}>
-      <h1 className="search-results-header">
-        {`${props.result.title} ${props.releaseYear(
-          props.result.release_date
-        )}`}
-      </h1>
       {/* TODO: Make image a link that will pass props to singlemovie component */}
       <img
         className="poster-img"
@@ -19,6 +14,12 @@ const ResultCard = props => {
         }
         alt={props.result.title}
       />
+      <h1 className="search-results-header">
+        {`${props.result.title}`}
+      </h1>
+      <p>{props.releaseYear(
+          props.result.release_date)}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
Edit Search Page so that captions are BELOW images

Edit so that there are more images per row

# Description

[Trello Card](https://trello.com/c/tK45L1Dq/180-search-ui-edits)

After feedback from Joshua, changed the number of search results per row -- and changed the caption to be below the poster image. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A - tested locally
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts