### PR TITLE
Fixed Issue on long components where it would not scroll to top

### DIFF
--- a/client/src/components/ScrollToTop.js
+++ b/client/src/components/ScrollToTop.js
@@ -1,0 +1,16 @@
+import { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+
+class ScrollToTop extends Component {
+    componentDidUpdate(prevProps) {
+      if (this.props.location.pathname !== prevProps.location.pathname) {
+        window.scrollTo(0, 0);
+      }
+    }
+  
+    render() {
+      return this.props.children;
+    }
+  }
+  
+  export default withRouter(ScrollToTop);

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -6,12 +6,15 @@ import App from './App';
 import * as serviceWorker from './services/serviceWorker';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
+import ScrollToTop from './components/ScrollToTop';
 
 require('dotenv').config();
 
 ReactDOM.render(
   <Router>
-    <App />
+    <ScrollToTop>
+      <App />
+    </ScrollToTop>
   </Router>,
   document.getElementById('root')
 );


### PR DESCRIPTION
# Description

[Trello Card](https://trello.com/c/7soCpGZe/266-when-changing-route-paths-on-long-components-page-does-not-scroll-back-to-top)

When changing route paths on long components page does not scroll back to top. Fixed this anomaly by creating a ScrollToTop that exports withRouter class that wraps around the <App /> 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A tested locally
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts